### PR TITLE
Fix(compass): Center compass needle on the dial

### DIFF
--- a/script.js
+++ b/script.js
@@ -383,7 +383,7 @@ function getBearingDirection(bearing) {
 // Update compass needle
 function updateCompassNeedle(bearing) {
     const needle = document.getElementById('compassNeedle');
-    needle.style.transform = `rotate(${bearing}deg)`;
+    needle.style.transform = `translate(-50%, -100%) rotate(${bearing}deg)`;
 }
 
 // Update radio calculations

--- a/styles.css
+++ b/styles.css
@@ -81,16 +81,9 @@ header p {
     height: 80px;
     transform: translate(-50%, -100%); /* base alignment only */
     transform-origin: 50% 100%;
-}
-
-/* Actual rotating needle */
-.needle {
-    width: 100%;
-    height: 100%;
     background: linear-gradient(to top, #2d3748 0% 50%, #e53e3e 50% 100%);
     border-radius: 2px;
-    transition: transform 0.5s ease; /* needle rotation happens here */
-    transform-origin: bottom center;
+    transition: transform 0.5s ease;
 }
 
 /* Labels */


### PR DESCRIPTION
The compass needle was not centered correctly because the `transform` property set in the CSS was being overwritten by the JavaScript `updateCompassNeedle` function, which only set the `rotate` property.

This commit fixes the issue by:
1. Consolidating the visual styles for the needle from a separate, unused `.needle` class into the `.compass-needle` class.
2. Updating the `updateCompassNeedle` function in `script.js` to include both the `translate(-50%, -100%)` and `rotate()` transforms, ensuring the needle remains centered as it rotates.