### PR TITLE
feat: Fix compass centering and improve responsive layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,7 +14,7 @@ body {
 }
 
 .container {
-    max-width: 1400px;
+    max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
 }
@@ -39,13 +39,17 @@ header p {
 
 /* Main content layout */
 .main-content {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
+    display: flex;
     gap: 30px;
     margin-bottom: 30px;
 }
 
 /* Panels */
+.controls-panel,
+.results-panel {
+    flex: 1;
+}
+
 .controls-panel,
 .results-panel,
 .map-container,
@@ -161,8 +165,14 @@ header p {
 /* Responsive */
 @media (max-width: 768px) {
     .main-content {
-        grid-template-columns: 1fr;
+        flex-direction: column;
         gap: 20px;
+    }
+    .controls-panel {
+        order: 2;
+    }
+    .results-panel {
+        order: 1;
     }
     .compass-rose {
         width: 150px;
@@ -170,6 +180,13 @@ header p {
     }
     .compass-needle {
         height: 60px;
+    }
+
+    input,
+    .btn-primary,
+    .btn-secondary {
+        padding: 14px;
+        font-size: 1.05rem;
     }
 }
 @media (max-width: 480px) {


### PR DESCRIPTION
This commit includes two main sets of changes:

1.  **Fix(compass): Center compass needle on the dial**

    The compass needle was not centered correctly because the JavaScript was overwriting the CSS transform property. The HTML structure was also missing the inner `.needle` element.

    This was fixed by:
    - Adding the `<div class="needle"></div>` to `index.html`.
    - Updating `script.js` to combine the `translate` and `rotate` transforms.

2.  **feat(responsive): Improve desktop and mobile layout**

    As a follow-up request, the responsive design of the page was enhanced.
    - The max-width of the main container was adjusted for better readability on large screens.
    - The main content panels on desktop were balanced to be equal height using flexbox.
    - The stacking order of panels on mobile was optimized to prioritize results.
    - The size of touch targets (buttons, inputs) was increased on mobile for better usability.